### PR TITLE
constraint-solver/.gitignore and package-version-parser/.gitignore updat...

### DIFF
--- a/packages/constraint-solver/.gitignore
+++ b/packages/constraint-solver/.gitignore
@@ -1,1 +1,2 @@
 .build*
+.npm

--- a/packages/package-version-parser/.gitignore
+++ b/packages/package-version-parser/.gitignore
@@ -1,1 +1,2 @@
 .build*
+.npm


### PR DESCRIPTION
...es to ignore .npm
I pulled the latest code to run through the build. The existence of .npm was a blocker. Ignoring it allowed a code pull and progress of the build to its current state.
